### PR TITLE
Update gecko.ps1 - Succesfully unload HKDU hive

### DIFF
--- a/solution/gecko.ps1
+++ b/solution/gecko.ps1
@@ -851,6 +851,7 @@ process {
             do {
                 fLogContent -fLogContent "Sleeping 15 secunds before attemting unloading Default User Registry hive" -fLogContentComponent "$region"
                 Start-Sleep -Seconds 15
+		[gc]::Collect()
                 $processResult = Start-Process -FilePath "$env:WINDIR\system32\reg.exe" -ArgumentList "UNLOAD $defaultUserRegistryRoot\$defaultUserRegistryKey" -WindowStyle Hidden -PassThru -Wait
                 $counter++
                 fLogContent -fLogContent "Unloading Default User Registry hive attempted [ $($processResult.ExitCode) | $($counter) ]" -fLogContentComponent "$region"


### PR DESCRIPTION
Doing some garbage collection to make sure the default user hive can be unloaded with success